### PR TITLE
Added support for graceful shutdown of go applications.

### DIFF
--- a/rerun.go
+++ b/rerun.go
@@ -88,7 +88,11 @@ func run(binName, binPath string, args []string) (runch chan bool) {
 		var proc *os.Process
 		for relaunch := range runch {
 			if proc != nil {
-				proc.Kill()
+				err := proc.Signal(os.Interrupt)
+				if err != nil {
+					log.Printf("error on sending signal to process: '%s', will now hard-kill the process\n", err)
+					proc.Kill()
+				}
 				proc.Wait()
 			}
 			if !relaunch {


### PR DESCRIPTION
Now using interrupt signal with fallback to proc.Kill().
Related to #11.
Don't know if this will work for all go programs out there. This patch assumes that the interrupt signal isn't (ab)used for other purposes than killing (such as reporting program status).
