### PR TITLE
Skip main package check if we're testing.

### DIFF
--- a/rerun.go
+++ b/rerun.go
@@ -170,7 +170,7 @@ func rerun(buildpath string, args []string) (err error) {
 		return
 	}
 
-	if pkg.Name != "main" {
+	if !(*do_tests) && pkg.Name != "main" {
 		err = errors.New(fmt.Sprintf("expected package %q, got %q", "main", pkg.Name))
 		return
 	}


### PR DESCRIPTION
Test package does not necessary have to be named `main` as do binary executable packages. This fix makes it skip the package name check if we're testing. But ideally I think we should also set `never_run` for these cases.