### PR TITLE
fix bin path issue when the path contains the package path also

### DIFF
--- a/rerun.go
+++ b/rerun.go
@@ -9,13 +9,15 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/howeyc/fsnotify"
 	"go/build"
 	"log"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
+	"runtime"
+
+	"github.com/howeyc/fsnotify"
 )
 
 var (
@@ -176,6 +178,11 @@ func rerun(buildpath string, args []string) (err error) {
 	}
 
 	_, binName := path.Split(buildpath)
+
+	if runtime.GOOS == "windows" {
+		binName = fmt.Sprintf("%s.exe", binName)
+	}
+
 	var binPath string
 	if gobin := os.Getenv("GOBIN"); gobin != "" {
 		binPath = filepath.Join(gobin, binName)

--- a/rerun.go
+++ b/rerun.go
@@ -15,7 +15,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
-	"runtime"
+	"strings"
 
 	"github.com/howeyc/fsnotify"
 )
@@ -179,16 +179,14 @@ func rerun(buildpath string, args []string) (err error) {
 
 	_, binName := path.Split(buildpath)
 
-	if runtime.GOOS == "windows" {
-		binName = fmt.Sprintf("%s.exe", binName)
-	}
-
 	var binPath string
 	if gobin := os.Getenv("GOBIN"); gobin != "" {
 		binPath = filepath.Join(gobin, binName)
 	} else {
 		binPath = filepath.Join(pkg.BinDir, binName)
 	}
+
+	binPath = strings.Replace(binPath, buildpath, filepath.Base(binName), -1)
 
 	var runch chan bool
 	if !(*never_run) {


### PR DESCRIPTION
Due to issues with windows not finding executable due to the '.exe' extension, added a small fix for windows runtime checks, also extended the library to provide more features by creating https://github.com/influx6/watch from this code. Thanks
