### PR TITLE
Changed CLI help display code, and added option to ignore names by regexp.

### DIFF
--- a/rerun.go
+++ b/rerun.go
@@ -231,8 +231,7 @@ func rerun(buildpath string, args []string) (err error) {
 		// read event from the watcher
 		we, _ := <-watcher.Event
 		// other files in the directory don't count - we watch the whole thing in case new .go files appear.
-		if fn := filepath.Base(we.Name) ;
-		(ignoreRe != nil && ignoreRe.FindString(fn) != "") || filepath.Ext(fn) != ".go" {
+		if fn := filepath.Base(we.Name); (ignoreRe != nil && ignoreRe.FindString(fn) != "") || filepath.Ext(fn) != ".go" {
 			continue
 		}
 

--- a/rerun.go
+++ b/rerun.go
@@ -279,10 +279,15 @@ func rerun(buildpath string, args []string) (err error) {
 }
 
 func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: %s [OPTIONS] IMPORT_PATH [ARGS]\nOptions:\n", os.Args[0])
+		flag.PrintDefaults()
+	}
 	flag.Parse()
 
 	if len(flag.Args()) < 1 {
-		log.Fatal("Usage: rerun [--test] [--no-run] [--build] [--race] <import path> [arg]*")
+		flag.Usage()
+		os.Exit(1)
 	}
 
 	buildpath := flag.Args()[0]

--- a/rerun.go
+++ b/rerun.go
@@ -9,18 +9,20 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/howeyc/fsnotify"
 	"go/build"
 	"log"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
+
+	"github.com/howeyc/fsnotify"
 )
 
 var (
 	do_tests      = flag.Bool("test", false, "Run tests (before running program)")
 	do_build      = flag.Bool("build", false, "Build program")
+	build_bin     = flag.String("bin", "", "Provide a specific path for the build binary")
 	never_run     = flag.Bool("no-run", false, "Do not run")
 	race_detector = flag.Bool("race", false, "Run program and tests with the race detector")
 )
@@ -83,11 +85,16 @@ func test(buildpath string) (passed bool, err error) {
 }
 
 func gobuild(buildpath string) (passed bool, err error) {
-	cmdline := []string{"go", "build"}
+	cmdline := []string{"go", "build", "-i"}
 
 	if *race_detector {
 		cmdline = append(cmdline, "-race")
 	}
+
+	if *build_bin != "" {
+		cmdline = append(cmdline, "-o", *build_bin)
+	}
+
 	cmdline = append(cmdline, "-v", buildpath)
 
 	// setup the build command, use a shared buffer for both stdOut and stdErr


### PR DESCRIPTION
Hi John,

Here's the modifications I made, in addition to Lachlan's:

- I changed help display code to use standard "flag" module's facility, to avoid having to update that one "Usage:" line every time there's a new flag.
- Added a flag to ignore files by regexp pattern; without it rerun also monitors temp files whose name merely prefixed (like emacs'). On malformed regexp, print error and ignore the regexp. I only need to check prefix, but this way maybe it'd be a bit more useful.